### PR TITLE
Update scaffold for Taqueria v0.24.1 Release

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,10 +23,10 @@
   },
   "homepage": "https://github.com/ecadlabs/taqueria-scaffold-taco-shop#readme",
   "devDependencies": {
-    "@taqueria/plugin-flextesa": "^0.22.2",
-    "@taqueria/plugin-jest": "^0.22.2",
-    "@taqueria/plugin-ligo": "^0.22.2",
-    "@taqueria/plugin-taquito": "^0.22.2",
+    "@taqueria/plugin-flextesa": "^0.24.1",
+    "@taqueria/plugin-jest": "^0.24.1",
+    "@taqueria/plugin-ligo": "^0.24.1",
+    "@taqueria/plugin-taquito": "^0.24.1",
     "@types/jest": "^29.0.0"
   },
   "main": "index.js",

--- a/quickstart.md
+++ b/quickstart.md
@@ -13,7 +13,7 @@ What you will accomplish:
 ## Requirements
 
 To successfully use Taqueria, you must ensure that:
-- The Taqueria CLI has been [installed](./installation.mdx) and is available in your `$PATH` 
+- The Taqueria CLI v0.24.1 has been [installed](./installation.mdx) and is available in your `$PATH` 
 - Docker v0.8 or later is installed and currently running
 - Node.js v16.3 or later
 


### PR DESCRIPTION
This PR updates the plugin versions to v0.24.1 and all references to the version in the quickstart